### PR TITLE
limit permission scope of github workflows

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -6,6 +6,9 @@ on:
     tags:
      - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   build-linux:
     runs-on: ubuntu-latest
@@ -29,7 +32,7 @@ jobs:
       with:
         name: linux
         path: dist/cg-manage-rds.ubuntu-latest.x64.zip
-  
+
   build-mac:
     runs-on: macos-latest
     steps:
@@ -97,6 +100,8 @@ jobs:
           dist/windows/cg-manage-rds.windows-latest.x64.zip
 
   update-formula:
+      permissions:
+        contents: write
       needs: release
       runs-on: ubuntu-latest
       steps:


### PR DESCRIPTION
## Changes proposed in this pull request:

- limit permission scope of github workflows

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations


This PR reduces the permissions of the workflows to the least privilege, rather than the defaults which may be overly permissive. This PR addresses active security alerts.
